### PR TITLE
add HOME var to spawned sub-processes, required for lockdown to function...

### DIFF
--- a/lockdown.js
+++ b/lockdown.js
@@ -168,7 +168,8 @@ server.listen(process.env['LOCKDOWN_PORT'] || 0, '127.0.0.1', function() {
     env: {
       NPM_CONFIG_REGISTRY: 'http://127.0.0.1:' + boundPort,
       NPM_LOCKDOWN_RUNNING: "true",
-      PATH: process.env['PATH']
+      PATH: process.env['PATH'],
+      HOME: process.env['HOME']
     },
     cwd: process.cwd()
   }, function(e) {


### PR DESCRIPTION
... on node 0.10 where node-gyp is in use - issue #22
