### PR TITLE
add the ability to specify which npm mirror to fetch resources from

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ You update your dependencies explicitly, relock, and commit:
 
 done!
 
+### Using an npm mirror
+
+You can fetch resources from an npm mirror by specifying the NPM_CONFIG_REGISTRY
+environment variable when invoking `npm install`. If NPM_CONFIG_REGISTRY is not
+specified, http://registry.npmjs.org will be used.
+
+    NPM_CONFIG_REGISTRY=http://registry.npmjs.eu/ npm install
+
 ## Notes:
 
   * You should use the latest stable version of lockdown, find it from the [npm registry](https://npmjs.org/package/lockdown)

--- a/lockdown.js
+++ b/lockdown.js
@@ -17,6 +17,10 @@ try {
   process.exit(1);
 }
 
+const registry = process.env['NPM_CONFIG_REGISTRY'] || 'registry.npmjs.org';
+
+console.log("using registry: " + registry);
+
 var boundPort;
 
 // during execution fatal errors will be appended to this list
@@ -26,7 +30,7 @@ var errors = [];
 var warn = [];
 
 function rewriteURL(u) {
-    return u.replace('registry.npmjs.org', '127.0.0.1:' + boundPort);
+    return u.replace(registry, '127.0.0.1:' + boundPort);
 }
 
 function packageOk(name, ver, sha, required) {
@@ -131,7 +135,7 @@ var server = http.createServer(function (req, res) {
   var hash = crypto.createHash('sha1');
 
   var r = http.request({
-    host: 'registry.npmjs.org',
+    host: registry,
     port: 80,
     method: req.method,
     path: req.url,


### PR DESCRIPTION
@lloyd, @zaach or @seanmonstar - could I get a review? This allows the user to specify an alternate NPM registry by specifying the `NPM_CONFIG_REGISTRY` environment variable. Using this with `http://registry.npmjs.eu` makes `npm install` blazing fast for the Persona repo for those of us in Europe.

For example:

```
~rm -rf node_modules
~time npm install                                                                                                             

> browserid@1.0.0-b2 preinstall /Users/stomlinson/development/browserid
> node ./scripts/lockdown

NPM Lockdown is here to check your dependencies!  Never fear!
using registry: registry.npmjs.org

> browserid@1.0.0-b2 preinstall /Users/stomlinson/development/browserid
> node ./scripts/lockdown

npm http GET http://127.0.0.1:52635/JSONSelect/0.4.0
npm http GET http://127.0.0.1:52635/cef/0.3.3
...
npm install  25.71s user 12.11s system 81% cpu 46.677 total
```

vs.

```
~rm -rf node_modules
~time NPM_CONFIG_REGISTRY=http://registry.npmjs.eu/ npm install 

> browserid@1.0.0-b2 preinstall /Users/stomlinson/development/browserid
> node ./scripts/lockdown

NPM Lockdown is here to check your dependencies!  Never fear!
using registry: http://registry.npmjs.eu/

> browserid@1.0.0-b2 preinstall /Users/stomlinson/development/browserid
> node ./scripts/lockdown

npm http GET http://registry.npmjs.eu/bcrypt/0.7.7
npm http GET http://registry.npmjs.eu/compute-cluster/0.0.6
...
NPM_CONFIG_REGISTRY=http://registry.npmjs.eu/ npm install  27.57s user 12.17s system 144% cpu 27.443 total
```
