### PR TITLE
Load npm config for registry details.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "node": ">=0.6.17"
   },
   "dependencies": {
-    "read-installed": "0.0.1",
-    "osenv": "0.0.3"
+    "npmconf": "1.1.1",
+    "osenv": "0.0.3",
+    "read-installed": "0.0.1"
   },
   "bin": {
     "lockdown": "./lockdown.js",


### PR DESCRIPTION
You can also use:
`NPM_CONFIG_REGISTRY=http://registry.npmjs.eu/ ./node_modules/.bin/lockdown-relock`

This is a backwards compatible fix with changes made in Npm 1.4.11

Fixes #29
