### PR TITLE
Fixing cache problems

### DIFF
--- a/relock.js
+++ b/relock.js
@@ -66,6 +66,8 @@ function walk (data, packages) {
   var name, version, shasum;
   if (data.name) name = data.name;
   if (data.version) version = data.version;
+  
+  if (packages[name] && packages[name][version]) return;
 
   if (name) {
     shasum = getShasum(cache, name, version);


### PR DESCRIPTION
This PR does three things:

- Fixes a bug that may end up generating an infinite loop, pointed out on issue #31 and fixed by https://github.com/jsebfranck/npm-lockdown/commit/f8f8b68bdd0f1be48a0f124eb95b0e495d88f6a0

- Adds additional exception treatment when looking for checksums, and includes a search by checksum in the package's packjson, contributed by @philippsimon

- Finally, substitutes the implementation of `findCache` to npmconf, and allows the usage of the env variable `NPM_CACHE_DIR` to point to a npm cache.