### PR TITLE
Update documentation about force publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ Well, they might...
   * ... accidentally introduce a subtle bug.
   * ... be having a bad day.
 
-And, any author at any time can overwrite the package version they have published
-so one under-thought `npm publish -f` can mean a subtle bug that steals days
-of your week.
-
 ## Usage!
 
 


### PR DESCRIPTION
Docs are a bit of out of date in a few places (e.g. bugs in `npm@1.x.x` around how `npm shrinkwrap` works), but here is a fix for another change since this was last released: _`npm publish -f` can no longer publish over existing versions._