### PR TITLE
Use .gitattributes to insure bins can be run. Fixes #42. v0.0.10-dev

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+ChangeLog text eol=lf
+LICENSE text eol=lf

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+0.0.10 -
+  * LF line endings to make executable.
 0.0.8 -
   * Fixes caching issues
 0.0.6 -

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lockdown",
   "description": "Lock your node.js app to specific versions (and checksums) of dependencies.",
-  "version": "0.0.8-dev",
+  "version": "0.0.10-dev",
   "author": "Lloyd Hilaiel <lloyd@hilaiel.com> (http://lloyd.io)",
   "bin": {
     "lockdown": "./lockdown.js",


### PR DESCRIPTION
It looks like a Windows machine was used to publish some of the previous
builds. That resulted in the js files having Windows line endings, which
breaks lockdown on all non-Windows systems. Use .gitattributes to
lockdown lockdown's line endings to LF, allowing bins to be run
anywhere.